### PR TITLE
Corrección de Menú en carrito

### DIFF
--- a/kondur-web-app/src/app/shared/header/carrito/carrito.component.html
+++ b/kondur-web-app/src/app/shared/header/carrito/carrito.component.html
@@ -1,5 +1,4 @@
 <div class="fondo-orange fullHeight">
-  <app-header></app-header>
   <div class="p-5">
     <h1 class="text-uppercase text-black fw-bold text-center pt-5">
       Mi carrito


### PR DESCRIPTION
El carrito tenia una etiqueta app-header repetida, lo que hacia ocultar la parte de arriba del menu hamburguesa